### PR TITLE
Use Mach time  when clock_gettime() not suppported

### DIFF
--- a/src/platform/posix/posix_clock.c
+++ b/src/platform/posix/posix_clock.c
@@ -59,7 +59,7 @@ nni_clock(void)
 #endif
 
 	if (clock_gettime(NNG_USE_CLOCKID, &ts) != 0) {
-		// This should never ever occur.                                                               
+		// This should never ever occur.
 		nni_panic("clock_gettime failed: %s", strerror(errno));
 	}
 

--- a/src/platform/posix/posix_clock.c
+++ b/src/platform/posix/posix_clock.c
@@ -28,45 +28,45 @@
 nni_time
 nni_clock(void)
 {
-        struct timespec ts;
-        nni_time        msec;
+	struct timespec ts;
+	nni_time        msec;
 
 #if __APPLE__
 
-        int supported = 0;
+	int supported = 0;
 
 #if defined(MAC_OS_X_VERSION_10_12) && __has_builtin(__builtin_available)
-        if (__builtin_available(macOS 10.12, *)) {
-                supported = 1;
-        }
+	if (__builtin_available(macOS 10.12, *)) {
+		supported = 1;
+	}
 #endif
 
-        if (!supported) {
-                // we could make this `__thread static` and read it only once,                                 
-                // not sure it's worth it, since the check for "the first time"                                
-                // introduces potential cache misses and other ways of making this                             
-                // run only once are more involved.                                                            
-                mach_timebase_info_data_t time_base_info;
+	if (!supported) {
+		// we could make this `__thread static` and read it only once,                                 
+		// not sure it's worth it, since the check for "the first time"                                
+		// introduces potential cache misses and other ways of making this                             
+		// run only once are more involved.                                                            
+		mach_timebase_info_data_t time_base_info;
 
-                // mach_continuous_time() is a better option, but it's only                                    
-                // available since MacOS 10.12, for which we already use clock_gettime().                      
-                uint64_t absolute_time = mach_absolute_time();
+		// mach_continuous_time() is a better option, but it's only                                    
+		// available since MacOS 10.12, for which we already use clock_gettime().                      
+		uint64_t absolute_time = mach_absolute_time();
 
-                mach_timebase_info(&time_base_info);
+		mach_timebase_info(&time_base_info);
 
-                return ((absolute_time * time_base_info.numer) / time_base_info.denom) / 10000000;
-        }
+		return ((absolute_time * time_base_info.numer) / time_base_info.denom) / 10000000;
+	}
 #endif
 
-        if (clock_gettime(NNG_USE_CLOCKID, &ts) != 0) {
-                // This should never ever occur.                                                               
-                nni_panic("clock_gettime failed: %s", strerror(errno));
-        }
+	if (clock_gettime(NNG_USE_CLOCKID, &ts) != 0) {
+		// This should never ever occur.                                                               
+		nni_panic("clock_gettime failed: %s", strerror(errno));
+	}
 
-        msec = ts.tv_sec;
-        msec *= 1000;
-        msec += (ts.tv_nsec / 1000000);
-        return (msec);
+	msec = ts.tv_sec;
+	msec *= 1000;
+	msec += (ts.tv_nsec / 1000000);
+	return (msec);
 }
 
 void

--- a/src/platform/posix/posix_clock.c
+++ b/src/platform/posix/posix_clock.c
@@ -31,7 +31,7 @@ nni_clock(void)
 	struct timespec ts;
 	nni_time        msec;
 
-#if __APPLE__
+#ifdef __APPLE__
 
 	int has_clock_gettime = 0;
 

--- a/src/platform/posix/posix_clock.c
+++ b/src/platform/posix/posix_clock.c
@@ -19,12 +19,65 @@
 
 #ifndef NNG_USE_GETTIMEOFDAY
 
+#if __APPLE__
+#include <mach/mach.h>
+#include <mach/mach_time.h>
+#endif
+
 // Use POSIX realtime stuff
 nni_time
 nni_clock(void)
 {
 	struct timespec ts;
 	nni_time        msec;
+
+#if __APPLE__
+
+#if defined(MAC_OS_X_VERSION_10_12) && __has_builtin(__builtin_available)
+	if (__builtin_available(macOS 10.12, *)) {
+		if (clock_gettime(NNG_USE_CLOCKID, &ts) != 0) {
+			// This should never ever occur.
+			nni_panic("clock_gettime failed: %s", strerror(errno));
+		}
+
+	  	msec = ts.tv_sec;
+	  	msec *= 1000;
+	  	msec += (ts.tv_nsec / 1000000);
+	  	return (msec);
+	}
+#endif
+
+	// we could make this `__thread static` and read it only once,
+	// not sure it's worth it, since the check for "the first time"
+	// introduces potential cache misses and other ways of making this
+	// run only once are more involved.
+	mach_timebase_info_data_t time_base_info;
+
+	// mach_continuous_time() is a better option, but it's only
+	// available since MacOS 10.12, for which we already use clock_gettime().
+	uint64_t absolute_time = mach_absolute_time();
+    
+        mach_timebase_info(&time_base_info);
+
+        return ((absolute_time * time_base_info.numer) / time_base_info.denom) / 10000000;
+	
+#if 0
+	// This is an alternative that is popular because it uses an almost
+	// equivalent call from Mach kernel, but it's _slow_. I left it here
+	// for us all to consider it as an option. I would not use it.
+	//
+	// it needs:
+	//#include <mach/clock.h>
+
+	clock_serv_t cclock;
+	mach_timespec_t mts;
+	host_get_clock_service(mach_host_self(), CALENDAR_CLOCK, &cclock);
+	clock_get_time(cclock, &mts);
+	mach_port_deallocate(mach_task_self(), cclock);
+	return (uint64_t)mts.tv_sec * 1000 + mts.tv_nsec / 1000000;
+#endif
+
+#else
 
 	if (clock_gettime(NNG_USE_CLOCKID, &ts) != 0) {
 		// This should never ever occur.
@@ -35,6 +88,8 @@ nni_clock(void)
 	msec *= 1000;
 	msec += (ts.tv_nsec / 1000000);
 	return (msec);
+
+#endif	
 }
 
 void

--- a/src/platform/posix/posix_clock.c
+++ b/src/platform/posix/posix_clock.c
@@ -58,6 +58,7 @@ nni_clock(void)
 	}
 #endif
 
+#if !defined(__APPLE__) || defined(MAC_OS_X_VERSION_10_12)
 	if (clock_gettime(NNG_USE_CLOCKID, &ts) != 0) {
 		// This should never ever occur.
 		nni_panic("clock_gettime failed: %s", strerror(errno));
@@ -67,6 +68,7 @@ nni_clock(void)
 	msec *= 1000;
 	msec += (ts.tv_nsec / 1000000);
 	return (msec);
+#endif
 }
 
 void

--- a/src/platform/posix/posix_clock.c
+++ b/src/platform/posix/posix_clock.c
@@ -19,7 +19,7 @@
 
 #ifndef NNG_USE_GETTIMEOFDAY
 
-#if __APPLE__
+#ifdef __APPLE__
 #include <mach/mach.h>
 #include <mach/mach_time.h>
 #endif

--- a/src/platform/posix/posix_clock.c
+++ b/src/platform/posix/posix_clock.c
@@ -33,15 +33,15 @@ nni_clock(void)
 
 #if __APPLE__
 
-	int supported = 0;
+	int has_clock_gettime = 0;
 
 #if defined(MAC_OS_X_VERSION_10_12) && __has_builtin(__builtin_available)
 	if (__builtin_available(macOS 10.12, *)) {
-		supported = 1;
+		has_clock_gettime = 1;
 	}
 #endif
 
-	if (!supported) {
+	if (!has_clock_gettime) {
 		// we could make this `__thread static` and read it only once,                                 
 		// not sure it's worth it, since the check for "the first time"                                
 		// introduces potential cache misses and other ways of making this                             


### PR DESCRIPTION
Older versions of MacOS did not support POSIX `clock_gettime()`, but newer do.
So, we have a runtime check to see if we're running on a MacOS that does support
it, and use the Mach kernel time APIs for older MacOSes. This does incur a runtime
check cost, but is a clear path forward for when the support for older MacOSes is
dropped.

There are some "for review" comments which are intended to be removed after
review is done, you'll discover then quickly. :)

After pondering for a while whether to somehow integrate this into the build/CMake,
I opted to leave it as a "code only" change with some macro magic... This does
make it a little ugly as we have to repeat the code that uses `clock_gettime()` twice,
but it's actually trivial code, which is done in 4 lines here, for whatever reason... Trying
to avoid that would make for even uglier macro trickery, and that's never good.